### PR TITLE
notes on the documentation as a whole as well as some edits

### DIFF
--- a/app/templates/components/docs-menu.hbs
+++ b/app/templates/components/docs-menu.hbs
@@ -1,7 +1,7 @@
 {{#bulma-menu }}
-  {{#bulma-menu-list label="Overview"}}
+  {{#bulma-menu-list label="Outline"}}
     <li>
-      {{link-to "Quickstart" "docs.index" class="item" activeClass="is-active"}}
+      {{#link-to "docs.index" class="item" activeClass="is-active"}}General{{/link-to}}
     </li>
     <li>
       {{#link-to "docs.plugins.getting-started" activeClass="is-active" class="item"}}Getting started{{/link-to}}

--- a/app/templates/docs/index.hbs
+++ b/app/templates/docs/index.hbs
@@ -1,22 +1,4 @@
-<h1>Quickstart</h1>
-<div class="card">
-  <div class="card-header">
-    <h2 class="card-header-title">The path of least resistance</h2>
-    <a href="#" class="card-header-icon" aria-label="more options">
-      <span class="icon">
-        <i class="fa fa-circle-o" aria-hidden="true"></i>
-      </span>
-    </a>
-  </div>
-  <div class="card-content">
-    <h3 class="is-4 subtitle">A quick deploy with an example implementation</h3>
-    <p>
-      An effortless way to have a flavour of the capabilities of the editor is to go and check the example implementation of
-      {{link-to "gelinkt-notuleren" "docs.implementations.from-repository" "lblod" "app-gelinkt-notuleren"}}. <br> <br>
-      Many of the documented plugins used here and it gives you a good idea of the possible user interactions with say-editor.
-    </p>
-  </div>
-</div>
+<h1>Overview</h1>
 
 <div class="card">
   <div class="card-header">
@@ -32,13 +14,18 @@
     <p>
       Given an existing ember-app, we'll show you how to integrate the say-editor in it. Check out the
       {{#link-to "docs.deploy-as-addon"}}tutorial{{/link-to}}.
+      <br> <br>
+      To see a real-world implementation, check out
+      {{link-to "gelinkt-notuleren" "docs.implementations.from-repository" "lblod" "app-gelinkt-notuleren"}}. <br>
+      Many of the documented plugins are used in this project. <br>
+      It will also give you a good idea of the possible user interactions with the say-editor.
     </p>
   </div>
 </div>
 
 <div class="card">
   <div class="card-header">
-    <h2 class="card-header-title">When your project doesn't talk Ember.js</h2>
+    <h2 class="card-header-title">Other implementations</h2>
       <a href="#" class="card-header-icon" aria-label="more options">
       <span class="icon">
         <i class="fa fa-plug" aria-hidden="true"></i>
@@ -48,9 +35,9 @@
   <div class="card-content">
     <h3 class="is-4 subtitle">Take a look at the following approaches!</h3>
     <p>
-      Convinced by the capabilities of say-editor, but disappointed your project doesn't talk in Ember.js?
-      <br> No need for sad feelings, there is still a way to use the editor in a complete framework agnostic way.
-      <br> You can either integrate it as an {{#link-to "docs.iframe-support"}}iFrame{{/link-to}} or
+      Convinced by the capabilities of the say-editor, but don't want to use Ember.js?<br>
+      Don't worry, we got you! There is still a way to use the editor in a framework-agnostic way.<br>
+      You can either integrate it as an {{#link-to "docs.iframe-support"}}iFrame{{/link-to}} or
       as an {{#link-to "docs.deploy-as-library"}}external JavaScript library{{/link-to}}.
     </p>
   </div>
@@ -58,7 +45,7 @@
 
 <div class="card">
   <div class="card-header">
-  <h2 class="card-header-title">When you are ready to make say smarter</h2>
+  <h2 class="card-header-title">Want to develop for the say-editor?</h2>
   <a href="#" class="card-header-icon" aria-label="more options">
   <span class="icon">
   <i class="fa fa-circle-o" aria-hidden="true"></i>
@@ -68,14 +55,13 @@
   <div class="card-content">
   <h3 class="is-4 subtitle">Write your first say plugin with a hands-on tutorial</h3>
   <p>
-    Doesn't the world lack knowledge?  Say doesn't understand
-    everything.  You may have a different need.  That's exactly why we
+    Say doesn't understand everything. You may have a different need. That's exactly why we
     wrote {{#link-to "docs.plugins.getting-started"}}this tutorial{{/link-to}} to get you started.
   </p>
   <p>
     Say makes it simple to add knowldge.  Follow the tutorial, learn
     to find the most relevant documentation, and make Say smarter for
-    your use.  Really, follow {{#link-to "docs.plugins.getting-started"}}the tutorial{{/link-to}}.
+    your use-case.
   </p>
   </div>
 </div>

--- a/public/assets/pages/getting-started.md
+++ b/public/assets/pages/getting-started.md
@@ -2,17 +2,19 @@
 
 Welcome to this getting started tutorial! In this tutorial we will enable some existing plugins and we will implement a new one. The tutorial assumes some basic knowledge of JavaScript.
 
+This video will give you a basic overview of what you will achieve by the end of this tutorial.
+
 <div class="c-video-wrapper">
   <iframe src="https://player.vimeo.com/video/401924173" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 </div>
 
 ## Setting up our environment
 
-The application we are building has a backend for minimal data storage and a frontend, written in Ember, containing the editor itself. The backend is hosted on a server. The frontend will run on your local machine and connect to the remote backend.
+The application we are building has a back-end for minimal data storage and a front-end written in Ember that contains the editor itself. The back-end is hosted on a server. The front-end will run on your local machine and connect to the remote back-end.
 
-### Setting up the frontend
+### Setting up the front-end
 
-We have prepared a frontend application with a basic editor installed.  This is going to be the basis of our testing.
+We have prepared a front-end application with a basic editor installed.  This is going to be the basis of our testing.
 
     git clone https://github.com/lblod/frontend-rdfa-editor-demo.git
     cd frontend-rdfa-editor-demo
@@ -21,11 +23,11 @@ You can start the application running the following npm command:
 
     npm run start
 
-The command will build and start the Ember application, proxy requests to the remote backend and live-reload on changes in the source files.
+The command will build and start the Ember application, proxy requests to the remote back-end and live-reload on changes in the source files.
 
 ### Verify the app is launched
 
-Once the build finished, visit http://localhost:4200 and view the wonder of a blank editor.
+Once the build has finished, visit http://localhost:4200 and view the wonder of a blank editor.
 
 ## Add existing plugins
 
@@ -82,7 +84,7 @@ If we can only reuse existing plugins, then we wouldn't be fully in control.  Le
 
 ### What do I need for a plugin?
 
-A general plugin has two moving parts.  A service, which receives events and tells Say in which regoins to show hint cards; and a component for user interaction such as rendering a hint card and updating the document.
+A general plugin has two moving parts.  A service, which receives events and tells Say in which regions to show hint cards; and a component for user interaction such as rendering a hint card and updating the document.
 
 ### Generating the stub configuration
 
@@ -118,7 +120,7 @@ With the plugin enabled, let's dive into the service.
 Our plugin's service will receive events.  When events are received, the service can update/add/remove hint cards.  Such calls are handled using the execute hook of the service.
 
 Our service is located in
-`frontend-rdfa-editor/demo/node_modules/@lblod/rdfa-editor-wikipedia-slug-plugin/addon/services/rdfa-editor-wikipedia-slug-plugin.js`.  Well, that's a very long path.  In other plugin development, your plugin would be a separate repository and you would follow the links with as root the `rdfa-editor-wikipedia-slug-plugin` folder.  Being able to clone one repository is nice though.
+`frontend-rdfa-editor-demo/node_modules/@lblod/rdfa-editor-wikipedia-slug-plugin/addon/services/rdfa-editor-wikipedia-slug-plugin.js`.  Well, that's a very long path.  In other plugin development, your plugin would be a separate repository and you would follow the links with as root the `rdfa-editor-wikipedia-slug-plugin` folder.  Being able to clone one repository is nice though.
 
 As we saw earlier, a generated service comes with a default hint card.  The service contains a single method which handles all the actions.
 
@@ -148,9 +150,8 @@ As we saw earlier, a generated service comes with a default hint card.  The serv
 From a high level the execute function goes like this:
 
   1. remove existing hints
-  2. for each context
-  3. if some property holds
-  4. add a hint card
+  2. do this for each context
+  3. if some property holds, add a hint card
 
 Each time new contexts are received, the service removes all hints and creates new hint cards on the relevant spots.
 
@@ -171,11 +172,11 @@ First things first, let's get an idea of the form of the rdfaBlocks array.  Let'
       ...
     }
 
-Opening up the developer console in the browser, you'll bee greeted with the content as you type new content.  Each block contains a bunch of information, inlcuding the semantic context.  For this demo we will simply hook into the text content.
+Opening up the developer console in the browser, you'll bee greeted with the content as you type new content.  Each block contains a bunch of information, including the semantic context.  For this demo we will simply hook into the text content.
 
 JavaScript has support for regular expressions.  Looking at the example inputs, a reasonable regular expression could be `/dbp:([\w_\-(%\d\d).]+\w)/`.  With this in our hands, we can update the matching function.
 
-Comment out the existing code in the for loop so the changes we make don't cause runtime errors.
+Comment out the existing code in the for loop so the changes we make don't cause run-time errors.
 
     for( const rdfaBlock of rdfaBlocks ){
       const match = rdfaBlock.text.match(/dbp:([\w_\-(%\d\d).]+\w)/);
@@ -214,7 +215,7 @@ Lastly, we need to add our highlight to the hintsRegistry.
 
 #### Adding the hint card
 
-A hint card informs the HintsRegistry wher cards should be shown.
+A hint card informs the HintsRegistry where cards should be shown.
 
 In between our calculations and the hint card being added, user input might be happening.  The HintsRegistry will help us out here based on the hrId.
 
@@ -252,7 +253,7 @@ You can find these files in:
 Looking at the card template, it still talks about "hello".  Let's update the card.  Some things to note:
 
   - You can render dynamic content between mustaches `{{ }}`
-  - You can access the imported info object starting wyth `@info`
+  - You can access the imported info object starting with `@info`
   - You can access definitions on the component under `this`
   - Arguments passed to Ember Components are prefixed with an `@`
   - You can render conditionals like `{{#if @info.term}}Yay{{else}}Nay{{/if}}`
@@ -288,7 +289,7 @@ Inserting the link is executed in three steps:
   - Select the previously highlighted area
   - Update the content of the selection
 
-Hinst can be removed by request to the HintsRegistry.  We passed this instance, the hrId and the location of our hint to this component so we can easily remove the hint:
+Hints can be removed by request to the HintsRegistry.  We passed this instance, the hrId and the location of our hint to this component so we can easily remove the hint:
 
     const info = this.args.info;
     info.hintsRegistry.removeHintsAtLocation( info.location, info.hrId, "dbp-slug-scope");
@@ -306,13 +307,13 @@ Lastly, we call the update function of the editor with this selection.  We reque
 
 That's it!  Press the button and your link should be inserted.
 
-Visiting this file you are greeted with a stub implementation for the execute function.  The documentation above indicates what information you receive, we wil use all of these in our solution.
+Visiting this file you are greeted with a stub implementation for the execute function.  The documentation above indicates what information you receive, we will use all of these in our solution.
 
 ### Enable the hint card
 
 If everything went to plan, you can now also enable the hint card to show some details about wikipedia links.  
 
-Enabling the `rdfa-editor-dbpedia-info-plugin` in `app/config/editor-profiles.js`.  After doing so, move your carret into one of the dbpedia links and you will be greated by an info card.
+Enabling the `rdfa-editor-dbpedia-info-plugin` in `app/config/editor-profiles.js`.  After doing so, move your caret into one of the dbpedia links and you will be greeted by an info card.
 
 ## Extra
 


### PR DESCRIPTION
```Legend
  - This is either my opinion that is probably wrong, a very nitpicky remark or something that is very low-priority.
  + Part of the pull request
  ! I personally think this is a priority but can't really do this myself in a reasonable amount of time
  * Probably a very large task to do

General notes
  ! cant find on google, as discussed its probably not even being indexed, for crawlability fastboot should be used from my understanding
  - assumes you know rdf and its advantages
  - assumes you understand the value of an rdf editor
  -* priority shouldn't be on ember it requires to much knowledge
  !* outdated documentation/demos should be updated
  + general writing improvements
  !* if we want people to stick around probably should make the editor less janky
  * we are using old ember syntax almost everywhere if someone wants to try embed the editor it might cause confusion/problems since they will probably come across octane first
  + if we cant make the tutorial work with all versions of ember, we should at least specify the version

Landing page
  - should probably explain the basics first. For a developer the descriptions seem opaque and high level, especially if they never used rdfa before.

Documentation

  Quickstart
    + should be renamed to something else
    + Improve the text and merge some elements

  Getting started
    * overwrite plugin is probably a poor choice of words maybe update-date-plugin, I assumed it overwrites the plugin not the date
    + video should be labeled better
    + change bullet-point list
    + some sentences need to be restructured
    - I personally feel uncomfortable with the destructure syntax used in match so other people might be too
    + paths need to change
    !* should update the demo or ask to use the plugin generator as it is right now someone who stumbles onto this page will probably give up as soon as they realize the tutorial doesn't match the provided sources
    
  Deploy as addon
    - app/config/editor-profiles.js already gets created when ember installing
    * we are using old ember syntax almost everywhere if someone wants to try embed the editor it might cause confusion/problems since they will probably come across octane first

  Deploy as a javascript library
    - unclear how to get the sources (couldn't find them in the repo, its just an ember app)
    - doesn't really work without them
```